### PR TITLE
Add Complete event to resizer event

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ You can pass an options hash to the plugin.
  - `parentSelector` - a selector representing the parent to vertically center this element within, ie. ".parent" (default: the element's immediate parent)
  - `debounceTimeout` - in milliseconds, used to rate-limit the vertical centering when resizing the browser window (default: 25)
  - `deferTilWindowLoad` - if true, no action will be taken until jQuery's window.load event fires. If false, the vertical centering will take place immediately, and then once again on window.load (default: false)
+ - `complete` - takes an anonymous function that gets run after the centering is complete. 
 
 Examples:
 
@@ -43,6 +44,7 @@ Examples:
     $('#element-to-be-centered').flexVerticalCenter();
     $('#element-to-be-centered').flexVerticalCenter({ cssAttribute: 'padding-top', verticalOffset: '50px' });
     $('#element-to-be-centered').flexVerticalCenter({ cssAttribute: 'padding-top', parentSelector: '.parent' });
+    $('#element-to-be-centered').flexVerticalCenter({ cssAttribute: 'padding-top', parentSelector: '.parent', complete: function(){ alert('I'm in the middle.... Vertically') } });
   });
   </script>
 ```

--- a/jquery.flexverticalcenter.js
+++ b/jquery.flexverticalcenter.js
@@ -32,6 +32,9 @@
         $this.css(
           settings.cssAttribute, ( ( ( parentHeight - $this.height() ) / 2 ) + parseInt(settings.verticalOffset) )
         );
+        if (options.complete !== undefined) {
+         options.complete();
+        }
       };
 
       // Call on resize. Opera debounces their resize by default.


### PR DESCRIPTION
Add Complete event to allow callback scripts. This is handy if you want to hide an element on load and then show it once centred
